### PR TITLE
#20 Bash script doesn't work on Mac. 

### DIFF
--- a/src/main/resources/bin/harvest
+++ b/src/main/resources/bin/harvest
@@ -39,7 +39,7 @@ if [ -n "$JAVA_HOME" ]; then
         exit 1
     fi
 else
-    $(java -version > /dev/nul 2>&1)
+    $(java -version > /dev/null 2>&1)
     if [[ $? -ne 0 ]] ; then
         echo "Java 1.8 or later is required to run Registry Manager."
         exit 1


### PR DESCRIPTION
Fixed /dev/nul. No other fixes are required to run on CentOS 8 and FreeBSD 12.1. I could not test on a Mac.

Resolves #20 